### PR TITLE
Add SKU to azurerm_public_ip resource

### DIFF
--- a/Terraform-Pack/network.tf
+++ b/Terraform-Pack/network.tf
@@ -19,6 +19,7 @@ resource "azurerm_public_ip" "main" {
   name                = "pip-${var.prefix}-${random_string.main.result}"
   location            = var.resource_group_location
   resource_group_name = azurerm_resource_group.main.name
+  sku                 = "Standard"
   allocation_method   = "Static"
   domain_name_label   = "${var.dns_name}-${random_string.main.result}"
 }


### PR DESCRIPTION
Not setting the sku here will default it to "Basic". Azure deprecated Basic public IPv4 addresses for all new subscriptions in September 2025.